### PR TITLE
레이아웃 컴포넌트, 컬러 팔레트 추가

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+import Header from '../Header';
+import Footer from '../Footer';
+import palette from '@/lib/styles/palette';
+
+interface LayoutProps {
+  children: React.ReactNode;
+  pathName: string;
+}
+
+function Layout({ children, pathName }: LayoutProps) {
+  const isHomePage = pathName === '/';
+  return (
+    <Container isHomePage={isHomePage}>
+      <Header />
+      <main>{children}</main>
+      <Footer />
+    </Container>
+  );
+}
+
+const Container = styled.div<{ isHomePage: boolean }>`
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+  min-height: 800px;
+  padding: 0 16px;
+  align-items: center;
+  ${({ isHomePage }) =>
+    isHomePage &&
+    css`
+      background-color: ${palette.background_blue};
+    `}
+
+  main {
+    display: block;
+    flex-basis: 100%;
+    width: 100%;
+    max-width: 1080px;
+  }
+`;
+
+export default Layout;

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Layout';

--- a/src/lib/styles/GlobalStyle.ts
+++ b/src/lib/styles/GlobalStyle.ts
@@ -1,5 +1,6 @@
 import reset from 'styled-reset';
 import { createGlobalStyle, css } from 'styled-components';
+import palette from './palette';
 
 const globalStyle = css`
   ${reset};
@@ -12,6 +13,7 @@ const globalStyle = css`
       'Noto Color Emoji';
     font-size: 16px;
     line-height: 1.75;
+    background-color: ${palette.background_white};
   }
   a {
     text-decoration: none;

--- a/src/lib/styles/palette.ts
+++ b/src/lib/styles/palette.ts
@@ -1,0 +1,18 @@
+export default {
+  background_white: '#EAEAEA', // 밝은 회색 배경
+  background_blue: '#5383e8', // 메인 페이지 배경
+  white: '#FFFFF', // 기본 흰색
+  black: '#22222', // 기본 블랙
+};
+
+/**
+ * font
+ * #c3cbd1 // 맨 위에 게임 리스트 글씨
+ * FFFFFF // 호버 및 일반
+ * B3CDFF // 위에 네비 호버 전 컬러
+ * #9b9b9b // 서치인풋 글씨
+ * #788185 // KR 박스
+ * #9c9c9c // 서치박스 비활성화 글씨
+ * #4a4a4a // 서치박스 활성화 글씨
+ * 666666 // 서치박스 - 최근 본 소환사 글씨
+ */

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,17 +1,25 @@
 import { AppProps } from 'next/app';
-import GlobalStyle from '@/lib/styles/GlobalStyle';
+import Head from 'next/head';
 
-function MyApp({ Component, pageProps }: AppProps) {
+import GlobalStyle from '@/lib/styles/GlobalStyle';
+import Layout from '@/components/Layout';
+
+function MyApp({ Component, pageProps, router }: AppProps) {
   return (
     <>
+      <ViewportMetaLink />
       <GlobalStyle />
-      <header>레이아웃 헤더</header>
-      <main>
+      <Layout pathName={router.pathname}>
         <Component {...pageProps} />
-      </main>
-      <footer>레이아웃 푸터</footer>
+      </Layout>
     </>
   );
 }
+
+const ViewportMetaLink = () => (
+  <Head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </Head>
+);
 
 export default MyApp;


### PR DESCRIPTION
## 개요
레이아웃 컴포넌트, 컬러 팔레트 추가
 
## 작업 내용
op.gg와 똑같이 화면 최대 너비 1080px로 설정
화면 높이는 100vh, 최소 높이 800px로 설정 
글로벌 배경색 설정
페이지나 컴포넌트 작업할 때 너비 100%로 하면 편하게 할 수 있음.
컬러 팔레트 추가했는데 오피지지 색이 너무 통일성이 없어서 당장은 필요 없을 듯

 
## 변경 로직(optional)
- 내용을 적어주세요.