### PR TITLE
스킬 탭(ChampionDetailsMain/DetailsContents/DetailsContentsSkill) 구현

### DIFF
--- a/src/components/ChampionDetails/ChampionDetailsMain/ChampionDetailsMain.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/ChampionDetailsMain.tsx
@@ -25,7 +25,7 @@ function ChampionDetailsMain({ champion }: ChampionDetailsMainProps) {
       <DetailsMainContanier>
         {type === 'ALL' && <DetailsContentAll champion={champion} />}
         {type === 'ITEM' && <DetailsContentItem />}
-        {type === 'SKILL' && <DetailsContentSkill />}
+        {type === 'SKILL' && <DetailsContentSkill champion={champion} />}
         {type === 'RUNE' && <DetailsContentRune />}
         {type === 'TRENDGRAPH' && <DetailsContentTrend />}
         {type === 'TIP' && <DetailsContentTip />}

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentAll/ItemTable/ItemTable.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentAll/ItemTable/ItemTable.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { coreDataOverview, bootsDataOverview } from '../../DetailsContentItem/itemData';
 
 function ItemTable() {
@@ -85,17 +86,17 @@ function ItemTable() {
           <td>
             <ul>
               {['6631', '3053', '3742'].map((item, i) => (
-                <>
-                  <li key={i}>
+                <React.Fragment key={item}>
+                  <li>
                     <img
                       src={`//opgg-static.akamaized.net/images/lol/item/${item}.png?image=q_auto:best&v=1617159801`}
                       alt=""
                     />
                   </li>
-                  <li className="arrow" key={i + 'arrow'}>
+                  <li className="arrow">
                     <img src="//opgg-static.akamaized.net/images/site/champion/blet.png" alt="" />
                   </li>
-                </>
+                </React.Fragment>
               ))}
             </ul>
           </td>
@@ -109,21 +110,21 @@ function ItemTable() {
           <td></td>
         </tr>
         {coreDataOverview.map((data, i) => (
-          <tr key={i}>
+          <tr key={'data1' + i}>
             <td>
               <ul>
                 {['first', 'second', 'third'].map((url, i) => (
-                  <>
-                    <li key={i + 'list'}>
+                  <React.Fragment key={url + i}>
+                    <li>
                       <img
                         src={`//opgg-static.akamaized.net/images/lol/item/${data[url]}.png?image=q_auto:best&v=1617159801`}
                         alt=""
                       />
                     </li>
-                    <li className="arrow" key={i + 'arrow'}>
+                    <li className="arrow">
                       <img src="//opgg-static.akamaized.net/images/site/champion/blet.png" alt="" />
                     </li>
-                  </>
+                  </React.Fragment>
                 ))}
               </ul>
             </td>
@@ -159,10 +160,10 @@ function ItemTable() {
           <td></td>
         </tr>
         {bootsDataOverview.map((data, i) => (
-          <tr key={i}>
+          <tr key={'data2' + i}>
             <td>
               <ul>
-                <li key={i + 'list'}>
+                <li>
                   <img
                     src={`//opgg-static.akamaized.net/images/lol/item/${data.url}.png?image=q_auto:best&v=1617159801`}
                     alt=""

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentAll/SideItems/styles.ts
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentAll/SideItems/styles.ts
@@ -37,5 +37,3 @@ export const ChampionBoxHeader = styled.div`
     }
   }
 `;
-
-export const ChampionBoxContent = styled.div``;

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentAll/SpellAndSkillTable/ChampionSkillBuildTable/ChampionSkillBuildTable.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentAll/SpellAndSkillTable/ChampionSkillBuildTable/ChampionSkillBuildTable.tsx
@@ -2,22 +2,21 @@ import React from 'react';
 import { Table } from './styles';
 
 interface TableProps {
-  levels: number[];
   build: string[];
 }
 
-function ChampionSkillBuildTable({ build, levels }: TableProps) {
+function ChampionSkillBuildTable({ build }: TableProps) {
   return (
     <Table>
       <tbody>
         <tr>
-          {levels.map((level) => (
-            <th key={level}>{level}</th>
+          {build.map((level, i) => (
+            <th key={'level' + i}>{i + 1}</th>
           ))}
         </tr>
         <tr>
           {build.map((skill, i) => (
-            <td key={i}>{skill}</td>
+            <td key={'skill' + i}>{skill}</td>
           ))}
         </tr>
       </tbody>

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentAll/SpellAndSkillTable/ChampionSkillBuildTable/styles.ts
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentAll/SpellAndSkillTable/ChampionSkillBuildTable/styles.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 export const Table = styled.table`
   margin-top: 10px;
-  margin-right: 0;
   table-layout: fixed;
   white-space: nowrap;
   tbody {
@@ -20,7 +19,8 @@ export const Table = styled.table`
         font-size: 11px;
         letter-spacing: -0.4px;
         color: #777;
-        width: 29px;
+        max-width: 29px;
+        min-width: 29px;
         height: 29px;
         vertical-align: middle;
         white-space: nowrap;
@@ -39,7 +39,7 @@ export const Table = styled.table`
         letter-spacing: -0.5px;
         text-align: center;
         color: #4a4a4a;
-        width: 29px;
+        max-width: 29px;
         height: 29px;
         vertical-align: middle;
         white-space: nowrap;

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentAll/SpellAndSkillTable/SpellAndSkillTable.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentAll/SpellAndSkillTable/SpellAndSkillTable.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import ChampionSkillBuildTable from './ChampionSkillBuildTable/ChampionSkillBuildTable';
 
 interface TableProps {
@@ -6,7 +7,7 @@ interface TableProps {
   build: string[];
 }
 
-function SpellAndSkillTable({ skills, levels, build }: TableProps) {
+function SpellAndSkillTable({ skills, build }: TableProps) {
   return (
     <>
       <thead>
@@ -104,17 +105,17 @@ function SpellAndSkillTable({ skills, levels, build }: TableProps) {
           <td>
             <ul>
               {skills.map((skill, i) => (
-                <>
-                  <li key={i}>
+                <React.Fragment key={'skillOverview' + i}>
+                  <li>
                     <img src={skill} alt="skill" />
                   </li>
-                  <li key={i + 'arrow'} className="arrow">
+                  <li className="arrow">
                     <img src="//opgg-static.akamaized.net/images/site/champion/blet.png" alt="" />
                   </li>
-                </>
+                </React.Fragment>
               ))}
             </ul>
-            <ChampionSkillBuildTable build={build} levels={levels} />
+            <ChampionSkillBuildTable build={build} />
           </td>
           <td className="pick-rate">
             <strong>49.5%</strong>

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentItem/CoreTable/CoreTable.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentItem/CoreTable/CoreTable.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { coreData, CoreType } from '../itemData';
 
 function CoreTable() {
@@ -21,8 +22,8 @@ function CoreTable() {
               <td className="cell-data">
                 <ul>
                   {['first', 'second', 'third'].map((url: string, i) => (
-                    <>
-                      <li key={i + 'list'}>
+                    <React.Fragment key={i + 'list'}>
+                      <li>
                         <img
                           src={`//opgg-static.akamaized.net/images/lol/item/${data[url]}.png?image=q_auto:best&v=1617159801`}
                           alt=""
@@ -34,7 +35,7 @@ function CoreTable() {
                           alt=""
                         />
                       </li>
-                    </>
+                    </React.Fragment>
                   ))}
                 </ul>
               </td>

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentItem/StartItemTable/StartItemTable.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentItem/StartItemTable/StartItemTable.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { startItemData, StartItemType } from '../itemData';
 
 function StartItemTable() {
@@ -21,7 +22,7 @@ function StartItemTable() {
               <td className="cell-data">
                 <ul>
                   {['first', 'second', 'third'].map((url: string, i) => (
-                    <>
+                    <React.Fragment key={i + url}>
                       {data[url] && (
                         <>
                           <li key={i + 'list'}>
@@ -33,7 +34,7 @@ function StartItemTable() {
                           <li className="arrow" key={i + 'arrow'}></li>
                         </>
                       )}
-                    </>
+                    </React.Fragment>
                   ))}
                 </ul>
               </td>

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentSkill/DetailsContentSkill.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentSkill/DetailsContentSkill.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Container,
   ContentMain,
@@ -15,8 +15,14 @@ import { ChampionDetailsMainProps } from '../../ChampionDetailsMain';
 import ChampionSkillBuildTable from '../DetailsContentAll/SpellAndSkillTable/ChampionSkillBuildTable/ChampionSkillBuildTable';
 
 function DetailsContentSkill({ champion }: ChampionDetailsMainProps) {
+  const [activeState, setActiveState] = useState(1);
+
   const championSkillUrl = getSkillsInfo(champion);
   const skills = championSkillUrl.slice(1, 4);
+
+  const toggleActive = (index: number) => {
+    setActiveState(index);
+  };
 
   const skillOrder = (skillOrder: string[], skills: string[]) => {
     let QCount = 0;
@@ -62,7 +68,10 @@ function DetailsContentSkill({ champion }: ChampionDetailsMainProps) {
           </div>
           <ChampionBoxContent>
             <ul className="filter">
-              <li className="filter-item active">
+              <li
+                className={activeState === 1 ? 'filter-item active' : 'filter-item'}
+                onClick={() => toggleActive(1)}
+              >
                 <ul className="skill-list">
                   {skillPriorities1.map((skill, i) => (
                     <React.Fragment key={'proiorites1' + skill + i}>
@@ -89,7 +98,10 @@ function DetailsContentSkill({ champion }: ChampionDetailsMainProps) {
                   </div>
                 </div>
               </li>
-              <li className="filter-item">
+              <li
+                className={activeState === 2 ? 'filter-item active' : 'filter-item'}
+                onClick={() => toggleActive(2)}
+              >
                 <ul className="skill-list">
                   {skillPriorities2.map((skill, i) => (
                     <React.Fragment key={'priorities2' + skill + i}>
@@ -133,8 +145,8 @@ function DetailsContentSkill({ champion }: ChampionDetailsMainProps) {
               </thead>
               <tbody>
                 {firstSkillOrder.map((order, i) => (
-                  <tr key={'firstSkillOrder' + i}>
-                    <td className="cell-data cell-skill">
+                  <tr key={'firstSkillOrder' + i} className={activeState !== 1 ? 'hide' : ''}>
+                    <td className={'cell-data cell-skill'}>
                       <ChampionSkillBuildTable build={order.skills} />
                     </td>
                     <td className="cell-skill cell-pick-rate">
@@ -144,7 +156,7 @@ function DetailsContentSkill({ champion }: ChampionDetailsMainProps) {
                   </tr>
                 ))}
                 {secondSkillOrder.map((order, i) => (
-                  <tr key={'secondSkillOrder' + i}>
+                  <tr key={'secondSkillOrder' + i} className={activeState !== 2 ? 'hide' : ''}>
                     <td className="cell-data cell-skill">
                       <ChampionSkillBuildTable build={order.skills} />
                     </td>

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentSkill/DetailsContentSkill.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentSkill/DetailsContentSkill.tsx
@@ -1,7 +1,166 @@
 import React from 'react';
+import {
+  Container,
+  ContentMain,
+  ContentSide,
+  ChampionBox,
+  ChampionBoxContent,
+} from '../DetailsContentSkill/styles';
+import {
+  getSkillsInfo,
+  firstSkillOrder,
+  secondSkillOrder,
+} from '@/components/ChampionDetails/championDetailsInfo';
+import { ChampionDetailsMainProps } from '../../ChampionDetailsMain';
+import ChampionSkillBuildTable from '../DetailsContentAll/SpellAndSkillTable/ChampionSkillBuildTable/ChampionSkillBuildTable';
 
-function DetailsContentSkill() {
-  return <div>스킬</div>;
+function DetailsContentSkill({ champion }: ChampionDetailsMainProps) {
+  const championSkillUrl = getSkillsInfo(champion);
+  const skills = championSkillUrl.slice(1, 4);
+
+  const skillOrder = (skillOrder: string[], skills: string[]) => {
+    let QCount = 0;
+    let WCount = 0;
+    let ECount = 0;
+    const skillOrderArray: string[] = [];
+    for (let i = 0; i < skillOrder.length; i++) {
+      if (skillOrder[i] === 'Q') QCount++;
+      else if (skillOrder[i] === 'W') WCount++;
+      else if (skillOrder[i] === 'E') ECount++;
+
+      // 스킬 5레벨 찍으면 skillOrderArray에 넣고 중복 삽입을 피하기 위해 0으로 세팅
+      if (QCount === 5) {
+        skillOrderArray.push(skills[0]);
+        QCount = 0;
+      }
+      if (WCount === 5) {
+        skillOrderArray.push(skills[1]);
+        WCount = 0;
+      }
+      if (ECount === 5) {
+        skillOrderArray.push(skills[2]);
+        ECount = 0;
+      }
+    }
+    if (QCount === 3) skillOrderArray.push(skills[0]);
+    else if (WCount === 3) skillOrderArray.push(skills[1]);
+    else if (ECount === 3) skillOrderArray.push(skills[2]);
+    return skillOrderArray;
+  };
+
+  const skillPriorities1 = skillOrder(firstSkillOrder[0].skills, skills);
+  const skillPriorities2 = skillOrder(secondSkillOrder[0].skills, skills);
+
+  // skillPriorities1.map((skill) => console.log(typeof Object.values(skill)));
+  // console.log(skillPriorities1);
+  return (
+    <Container>
+      <ContentMain>
+        <ChampionBox>
+          <div className="champion-box-header">
+            <h4>스킬 순서</h4>
+          </div>
+          <ChampionBoxContent>
+            <ul className="filter">
+              <li className="filter-item active">
+                <ul className="skill-list">
+                  {skillPriorities1.map((skill, i) => (
+                    <React.Fragment key={'proiorites1' + skill + i}>
+                      <li>
+                        <img src={skill} alt="skill" />
+                      </li>
+                      <li className="arrow">
+                        <img
+                          src="//opgg-static.akamaized.net/images/site/champion/blet.png"
+                          alt=""
+                        />
+                      </li>
+                    </React.Fragment>
+                  ))}
+                </ul>
+                <div className="item-value">
+                  <div className="rate">
+                    <span>픽률</span>
+                    <b>96.47%</b>
+                  </div>
+                  <div className="rate">
+                    <span>승률</span>
+                    <b>64.11%</b>
+                  </div>
+                </div>
+              </li>
+              <li className="filter-item">
+                <ul className="skill-list">
+                  {skillPriorities2.map((skill, i) => (
+                    <React.Fragment key={'priorities2' + skill + i}>
+                      <li key={'skillPriorities2' + i}>
+                        <img src={skill} alt="skill" />
+                      </li>
+                      <li key={'arrow2' + skill + i} className="arrow">
+                        <img
+                          src="//opgg-static.akamaized.net/images/site/champion/blet.png"
+                          alt=""
+                        />
+                      </li>
+                    </React.Fragment>
+                  ))}
+                </ul>
+                <div className="item-value">
+                  <div className="rate">
+                    <span>픽률</span>
+                    <b>3.53%</b>
+                  </div>
+                  <div className="rate">
+                    <span>승률</span>
+                    <b>62.50%</b>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </ChampionBoxContent>
+        </ChampionBox>
+      </ContentMain>
+      <ContentSide>
+        <ChampionBox>
+          <ChampionBoxContent>
+            <table>
+              <thead>
+                <tr>
+                  <th className="title">스킬</th>
+                  <th className="sort">픽률</th>
+                  <th className="sort">승률</th>
+                </tr>
+              </thead>
+              <tbody>
+                {firstSkillOrder.map((order, i) => (
+                  <tr key={'firstSkillOrder' + i}>
+                    <td className="cell-data cell-skill">
+                      <ChampionSkillBuildTable build={order.skills} />
+                    </td>
+                    <td className="cell-skill cell-pick-rate">
+                      {order.pickRate}%<em>{order.pickCount}</em>
+                    </td>
+                    <td className="cell-skill cell-win-rate">{order.winRate}%</td>
+                  </tr>
+                ))}
+                {secondSkillOrder.map((order, i) => (
+                  <tr key={'secondSkillOrder' + i}>
+                    <td className="cell-data cell-skill">
+                      <ChampionSkillBuildTable build={order.skills} />
+                    </td>
+                    <td className="cell-skill cell-pick-rate">
+                      {order.pickRate}%<em>{order.pickCount}</em>
+                    </td>
+                    <td className="cell-skill cell-win-rate">{order.winRate}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </ChampionBoxContent>
+        </ChampionBox>
+      </ContentSide>
+    </Container>
+  );
 }
 
 export default DetailsContentSkill;

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentSkill/styles.ts
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentSkill/styles.ts
@@ -1,3 +1,197 @@
 import styled from 'styled-components';
 
-export const DetailsContentSkill = styled.div``;
+export const Container = styled.div`
+  display: flex;
+  width: 1080px;
+  margin: 10px auto 0;
+`;
+
+export const ContentMain = styled.div`
+  width: 228px;
+`;
+
+export const ContentSide = styled.div`
+  width: 842px;
+  margin-left: 8px;
+`;
+
+export const ChampionBox = styled.div`
+  margin-top: 10px;
+  background-color: #f9f9fa;
+  border: solid 1px #e6e6e6;
+  div.champion-box-header {
+    position: relative;
+    background: #fff;
+    border-bottom: 1px solid #e6e6e6;
+    text-align: left;
+    h4 {
+      padding: 12px 0 11px 20px;
+      line-height: 17px;
+      font-size: 14px;
+      color: #222;
+      letter-spacing: -0.2px;
+      font-weight: bold;
+    }
+  }
+`;
+
+export const ChampionBoxContent = styled.div`
+  background: #fafafa;
+  overflow: hidden;
+  ul.filter {
+    li.filter-item {
+      border-left: 8px solid transparent;
+      padding: 13px 0 13px 22px;
+      background-color: #f9f9fa;
+      border-top: solid 1px #e9eff4;
+      cursor: pointer;
+      ul.skill-list {
+        display: flex;
+        font-size: 0;
+        list-style: none;
+        li {
+          position: relative;
+          width: 42px;
+          height: 42px;
+          img {
+            width: 100%;
+            border: 1px solid #000;
+            border-radius: 2px;
+            display: block;
+            box-sizing: border-box;
+          }
+        }
+        li.arrow {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 20px;
+          height: 42px;
+          img {
+            width: 6px;
+            height: 11px;
+            vertical-align: middle;
+            border: 0;
+          }
+        }
+        li.arrow:last-child {
+          display: none;
+        }
+      }
+      div.item-value {
+        display: table;
+        margin-top: 10px;
+        div.rate {
+          display: table-row;
+          line-height: 15px;
+          span {
+            padding-top: 5px;
+            display: table-cell;
+            font-size: 12px;
+          }
+          b {
+            display: table-cell;
+            padding-top: 4px;
+            padding-left: 10px;
+            font-size: 13px;
+            font-weight: normal;
+            color: #222;
+          }
+        }
+        div.rate:first-child {
+          b {
+            font-weight: 600;
+          }
+        }
+      }
+    }
+    li.filter-item:first-child {
+      border-top: none;
+    }
+    li.filter-item.active {
+      border-left-color: #3c8eec;
+      background: #fff;
+    }
+  }
+
+  table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+    border-spacing: 0;
+    thead {
+      tr {
+        th {
+          vertical-align: middle;
+          height: 39px;
+          background: #fff;
+          border-bottom: 1px solid #e9eff4;
+          line-height: 17px;
+          font-size: 14px;
+          color: #b6b6b6;
+          font-weight: normal;
+          text-align: center;
+          width: 95px;
+          background-image: url(../images/site/champion/select-over.png);
+          background-repeat: no-repeat;
+          background-position: right 20px center;
+        }
+        th.title {
+          background-image: none;
+          cursor: default;
+          width: auto;
+          text-align: left;
+          font-weight: bold;
+          color: #222;
+          padding-left: 20px;
+        }
+        th.sort {
+          background-image: url(../images/site/bg-tableSorter.png);
+          background-repeat: no-repeat;
+          background-position: 90% center;
+          cursor: pointer;
+          outline: none;
+        }
+      }
+    }
+    tbody {
+      tr {
+        table {
+          margin: 10px 0;
+          max-width: 485px;
+        }
+        td.cell-skill {
+          vertical-align: middle;
+          height: 62px;
+          background: #f5f5f5;
+          text-align: center;
+          font-size: 13px;
+          color: #666;
+        }
+        td.cell-data {
+          padding-left: 30px;
+          text-align: left;
+        }
+        td.cell-pick-rate {
+          font-weight: bold;
+          color: #4a4a4a;
+          em {
+            display: block;
+            font-size: 11px;
+            color: #999;
+            font-style: normal;
+          }
+        }
+        td.cell-win-rate {
+          font-weight: normal;
+          color: #4a4a4a;
+        }
+      }
+      tr:nth-child(even) {
+        td.cell-skill {
+          background: #ebebed;
+        }
+      }
+    }
+  }
+`;

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentSkill/styles.ts
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentSkill/styles.ts
@@ -187,6 +187,9 @@ export const ChampionBoxContent = styled.div`
           color: #4a4a4a;
         }
       }
+      tr.hide {
+        display: none;
+      }
       tr:nth-child(even) {
         td.cell-skill {
           background: #ebebed;

--- a/src/components/ChampionDetails/championDetailsInfo.ts
+++ b/src/components/ChampionDetails/championDetailsInfo.ts
@@ -25,3 +25,69 @@ export const precisionRune = [
   ['9104', '9105', '9103'],
   ['8014', '8017', '8299'],
 ];
+
+export const firstSkillOrder = [
+  {
+    skills: ['Q', 'W', 'E', 'Q', 'Q', 'R', 'Q', 'E', 'Q', 'E', 'R', 'E', 'E', 'W', 'W'],
+    pickRate: 33.88,
+    pickCount: 207,
+    winRate: 60.87,
+  },
+  {
+    skills: ['Q', 'E', 'W', 'Q', 'Q', 'R', 'Q', 'E', 'Q', 'E', 'R', 'E', 'E', 'W', 'W'],
+    pickRate: 32.9,
+    pickCount: 201,
+    winRate: 66.67,
+  },
+  {
+    skills: ['W', 'Q', 'E', 'Q', 'Q', 'R', 'Q', 'E', 'Q', 'E', 'R', 'E', 'E', 'W', 'W'],
+    pickRate: 14.08,
+    pickCount: 86,
+    winRate: 67.47,
+  },
+  {
+    skills: ['W', 'E', 'Q', 'Q', 'Q', 'R', 'Q', 'E', 'Q', 'E', 'R', 'E', 'E', 'W', 'W'],
+    pickRate: 9.17,
+    pickCount: 56,
+    winRate: 53.57,
+  },
+  {
+    skills: ['E', 'Q', 'W', 'Q', 'Q', 'R', 'Q', 'E', 'Q', 'E', 'R', 'E', 'E', 'W', 'W'],
+    pickRate: 1.8,
+    pickCount: 11,
+    winRate: 72.73,
+  },
+];
+
+export const secondSkillOrder = [
+  {
+    skills: ['Q', 'W', 'E', 'Q', 'Q', 'R', 'Q', 'W', 'Q', 'W', 'R', 'W', 'W', 'E', 'E'],
+    pickRate: 0.98,
+    pickCount: 6,
+    winRate: 66.67,
+  },
+  {
+    skills: ['W', 'Q', 'E', 'Q', 'Q', 'R', 'Q', 'W', 'Q', 'W', 'R', 'W', 'W', 'E', 'E'],
+    pickRate: 0.82,
+    pickCount: 5,
+    winRate: 60.0,
+  },
+  {
+    skills: ['Q', 'E', 'W', 'Q', 'Q', 'R', 'Q', 'W', 'Q', 'W', 'R', 'W', 'W', 'E', 'E'],
+    pickRate: 0.65,
+    pickCount: 4,
+    winRate: 75.0,
+  },
+  {
+    skills: ['W', 'E', 'Q', 'Q', 'Q', 'R', 'Q', 'W', 'Q', 'W', 'R', 'W', 'W', 'E', 'E'],
+    pickRate: 0.33,
+    pickCount: 2,
+    winRate: 50.0,
+  },
+  {
+    skills: ['Q', 'E', 'W', 'Q', 'Q', 'R', 'Q', 'W', 'Q', 'W', 'R', 'E', 'W', 'W', 'E'],
+    pickRate: 0.16,
+    pickCount: 1,
+    winRate: 0.0,
+  },
+];


### PR DESCRIPTION
## 개요 🪧

- 스킬 탭 구현
 
## 작업 내용 📄

- 스킬 선 마스터 순서에 따른 탭 메뉴 기능
- map 메소드 key 문제 해결

## 변경 로직 ⚙️

- 스킬 찍는 순서와 픽/승률 데이터를 championDetailsInfo로 따로 빼서 분리했습니다

## 스크린샷 📸

![image](https://user-images.githubusercontent.com/73068489/114836786-f6f5cf00-9e0d-11eb-9f32-6145958dd31c.png)
![image](https://user-images.githubusercontent.com/73068489/114836807-fbba8300-9e0d-11eb-9618-b38ad276a570.png)
