### PR TITLE
HoverContainer 추가

### DIFF
--- a/src/components/Champions/ContentSide/ContentSideList/ChampionRankTable/ChampionRankTable.tsx
+++ b/src/components/Champions/ContentSide/ContentSideList/ChampionRankTable/ChampionRankTable.tsx
@@ -6,6 +6,7 @@ import { ChampionRankTableProps, ChampionRankTableHeaderMap } from './types';
 import { useContext } from 'react';
 import { ChampionRankContext } from '@/pages/champions';
 import RankTableBody from './RankTableBody';
+import HoverContainer from '@/components/Common/HoverContainer';
 
 const ChampionRankTableColGroup = (navItem: ChampionsContentSideNavbarType) => {
   if (navItem === '티어') {
@@ -43,6 +44,8 @@ const ChampionRankTableColGroup = (navItem: ChampionsContentSideNavbarType) => {
 
 const ChampionRankTable = ({ navItem, tabItem }: ChampionRankTableProps) => {
   const rankData = useContext(ChampionRankContext);
+  const hoverText =
+    '챔프티어는 플레티넘 티어 이상 게임의 밴픽률, 승률, 골드, 경험치, 군중제어, KDA, 받은 데미지, 가한 데미지 등 다양한 데이터를 추출해 만들어집니다. (대회나 천상계와는 다를 수 있습니다.)';
   if (rankData === undefined) {
     return <></>;
   }
@@ -57,7 +60,19 @@ const ChampionRankTable = ({ navItem, tabItem }: ChampionRankTableProps) => {
                 {header}
               </th>
             ) : (
-              <th key={header}>{header}</th>
+              <th key={header} className={header === '티어' ? 'tier' : 'common'}>
+                {header}
+                {header === '티어' && (
+                  <HoverContainer
+                    title={'테스트'}
+                    text={hoverText}
+                    intervalLeft={'-131px'}
+                    intervalTop={'-110px'}
+                  >
+                    <img src="assets/champions/icon-tip.png" alt="tip" />
+                  </HoverContainer>
+                )}
+              </th>
             ),
           )}
         </tr>

--- a/src/components/Champions/ContentSide/ContentSideList/ChampionRankTable/ChampionRankTable.tsx
+++ b/src/components/Champions/ContentSide/ContentSideList/ChampionRankTable/ChampionRankTable.tsx
@@ -61,12 +61,12 @@ const ChampionRankTable = ({ navItem, tabItem }: ChampionRankTableProps) => {
               </th>
             ) : (
               <th key={header} className={header === '티어' ? 'tier' : 'common'}>
-                {header}
+                {header + ' '}
                 {header === '티어' && (
                   <HoverContainer
                     title={'테스트'}
                     text={hoverText}
-                    intervalLeft={'-131px'}
+                    intervalLeft={'-130px'}
                     intervalTop={'-110px'}
                   >
                     <img src="assets/champions/icon-tip.png" alt="tip" />

--- a/src/components/Champions/ContentSide/ContentSideList/ChampionRankTable/styles.ts
+++ b/src/components/Champions/ContentSide/ContentSideList/ChampionRankTable/styles.ts
@@ -23,15 +23,17 @@ export const RankTableHead = styled.thead`
       color: #777;
     }
     th.tier {
-      position: relative;
-      padding-left: 20px;
-      text-align: left;
+      padding-top: 2px;
       div {
-        position: absolute;
+        display: inline-block;
+
+        vertical-align: middle;
         margin: 0;
-        padding: 0;
-        top: 15px;
-        right: 20px;
+        line-height: 15px;
+        img {
+          margin-left: 2px;
+          line-height: 15px;
+        }
       }
     }
   }

--- a/src/components/Champions/ContentSide/ContentSideList/ChampionRankTable/styles.ts
+++ b/src/components/Champions/ContentSide/ContentSideList/ChampionRankTable/styles.ts
@@ -22,6 +22,18 @@ export const RankTableHead = styled.thead`
       font-weight: normal;
       color: #777;
     }
+    th.tier {
+      position: relative;
+      padding-left: 20px;
+      text-align: left;
+      div {
+        position: absolute;
+        margin: 0;
+        padding: 0;
+        top: 15px;
+        right: 20px;
+      }
+    }
   }
 `;
 

--- a/src/components/Champions/index.tsx
+++ b/src/components/Champions/index.tsx
@@ -1,4 +1,5 @@
 // styled-components
+import HoverContainer from '../Common/HoverContainer';
 import { ChampionsPageContainer, MessageSection, ChampionsContentSection } from './style';
 
 interface ChampionsPageProps {
@@ -6,6 +7,8 @@ interface ChampionsPageProps {
 }
 
 const ChampionsPage = ({ children }: ChampionsPageProps) => {
+  const hoverText =
+    '현재 한국이외의 데이터가 충분하지 않습니다. 해외 서버의 데이터가 확보되면 지역 기반 챔피언 데이터를 제공할 예정입니다.';
   return (
     <ChampionsPageContainer>
       <MessageSection>
@@ -13,7 +16,9 @@ const ChampionsPage = ({ children }: ChampionsPageProps) => {
           챔피언 분석은 플래티넘 티어 이상의 랭크 게임만을 수집힙니다.
         </p>
         <p className="message__right">
-          <img src="assets/champions/icon-tip.png" alt="tip" />
+          <HoverContainer text={hoverText}>
+            <img src="assets/champions/icon-tip.png" alt="tip" />
+          </HoverContainer>
           Korea-버전 : 11.07
         </p>
       </MessageSection>

--- a/src/components/Champions/style.ts
+++ b/src/components/Champions/style.ts
@@ -11,13 +11,12 @@ export const MessageSection = styled.section`
   justify-content: space-between;
   margin-bottom: 10px;
   p.message__left {
-    float: left;
     line-height: 18px;
     font-size: 12px;
     color: #9b9b9b;
   }
   p.message__right {
-    float: right;
+    display: flex;
     line-height: 18px;
     font-size: 12px;
     text-align: right;
@@ -47,5 +46,4 @@ export const ChampionImage = styled.div.attrs(({ width, idx, isRotation }: Champ
     height: width + 'px',
     backgroundPositionY: '-' + idx * parseInt(width) + 'px',
   },
-}))<ChampionImageProps>`
-`;
+}))<ChampionImageProps>``;

--- a/src/components/Common/HoverContainer/HoverContainer.tsx
+++ b/src/components/Common/HoverContainer/HoverContainer.tsx
@@ -1,0 +1,28 @@
+import * as S from './styles';
+
+interface HoverContainerProps {
+  children: JSX.Element;
+  title?: string;
+  text: string;
+  intervalTop?: string;
+  intervalLeft?: string;
+}
+const HoverContainer = ({
+  children,
+  title,
+  text,
+  intervalTop,
+  intervalLeft,
+}: HoverContainerProps) => {
+  return (
+    <S.Container>
+      <S.HoverContent left={intervalLeft} top={intervalTop}>
+        {title && <p className="title">{title}</p>}
+        <p className="text">{text}</p>
+      </S.HoverContent>
+      {children}
+    </S.Container>
+  );
+};
+
+export default HoverContainer;

--- a/src/components/Common/HoverContainer/index.ts
+++ b/src/components/Common/HoverContainer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HoverContainer';

--- a/src/components/Common/HoverContainer/styles.ts
+++ b/src/components/Common/HoverContainer/styles.ts
@@ -6,8 +6,8 @@ interface HoverContentProps {
 }
 
 export const HoverContent = styled.div<HoverContentProps>`
-  position: absolute;
-  display: none;
+  position: absolute !important;
+  display: none !important;
   width: 300px;
   padding: 10px !important;
   top: ${(props) => (props.top ? props.top : '-87px')} !important;
@@ -34,10 +34,10 @@ export const HoverContent = styled.div<HoverContentProps>`
   }
 `;
 export const Container = styled.div`
-  position: relative;
+  position: relative !important;
   &:hover {
     ${HoverContent} {
-      display: block;
+      display: block !important;
     }
   }
 `;

--- a/src/components/Common/HoverContainer/styles.ts
+++ b/src/components/Common/HoverContainer/styles.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+interface HoverContentProps {
+  top?: string;
+  left?: string;
+}
+
+export const HoverContent = styled.div<HoverContentProps>`
+  position: absolute;
+  display: none;
+  width: 300px;
+  padding: 10px !important;
+  top: ${(props) => (props.top ? props.top : '-87px')} !important;
+  left: ${(props) => (props.left ? props.left : '-131px')} !important;
+  background-color: #111;
+  color: white;
+  font-size: 12px;
+  text-align: left;
+  z-index: 9999;
+  &:after {
+    position: absolute;
+    border-top: 10px solid #111;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 0 solid transparent;
+    content: '';
+    bottom: -10px;
+    left: 130px;
+    z-index: 9998;
+  }
+  p.title {
+    font-weight: bold;
+    color: #ffc659;
+  }
+`;
+export const Container = styled.div`
+  position: relative;
+  &:hover {
+    ${HoverContent} {
+      display: block;
+    }
+  }
+`;


### PR DESCRIPTION
## 개요 🪧

- Hover시 도움말 형식으로 나오는 컴포넌트가 여러 페이지에서 사용되는 것을 확인함.
- 부모 컨테이너로 감싸서 사용하도록 Hover 컨테이너를 추가함
 
## 작업 내용 📄

- HoverContainer의 props로 title, text, top, left를 통해 컨텐츠와 컨테이너 위치를 조정할 수 있음.
- position: absolute로 설정되어 조정이 가능하지만 **_컨텐츠의 양이 많아지면 하드코딩_** 으로 조정해야함.

## 변경 로직 ⚙️

![스크린샷 2021-04-15 오후 9 41 13](https://user-images.githubusercontent.com/61958795/114870606-531f1a00-9e33-11eb-8d64-74ac762f4940.png)

- 사용시 intervalTop, intervalLeft에 px를 포함한 문자열을 props로 넘겨야함. (ex. intervalTop={"-120px"})

## 스크린샷 📸
<img width="400" alt="스크린샷 2021-04-15 오후 9 40 20" src="https://user-images.githubusercontent.com/61958795/114870467-2ec33d80-9e33-11eb-8b36-a3959c46f441.png">

closes #23
