### PR TITLE
룬 탭(ChampionDetailsMain/DetailsContents/DetailsContentsRune)

### DIFF
--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/DetailsContentRune.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/DetailsContentRune.tsx
@@ -1,7 +1,55 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Container, ContentSide, ContentMain, ChampionBox, ChampionBoxContent } from './styles';
+import { keystones, keystonesType } from '@/components/ChampionDetails/championDetailsInfo';
 
 function DetailsContentRune() {
-  return <div>룬</div>;
+  const [activeState, setActiveState] = useState(1);
+
+  const toggleActive = (index: number) => {
+    setActiveState(index);
+  };
+
+  return (
+    <Container>
+      <ContentMain>
+        <ChampionBox>
+          <div className="champion-box-header">
+            <h4>키스톤</h4>
+          </div>
+          <ChampionBoxContent>
+            <ul className="filter">
+              {keystones.map((rune, i) => (
+                <li
+                  key={rune.pickRate + i}
+                  className={activeState === 1 + i ? 'filter-item active' : 'filter-item'}
+                  onClick={() => toggleActive(1 + i)}
+                >
+                  <img src={rune.mainRune} className="rune" alt="메인룬" />
+                  <img src={rune.keystone} className="rune keystone" alt="키스톤" />
+                  <img src={rune.subRune} className="rune sub-rune" alt="보조룬" />
+                  <div className="item-value">
+                    <div className="rate">
+                      <span>픽률</span>
+                      <b>{rune.pickRate}%</b>
+                    </div>
+                    <div className="rate">
+                      <span>승률</span>
+                      <b>{rune.winRate}%</b>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </ChampionBoxContent>
+        </ChampionBox>
+      </ContentMain>
+      <ContentSide>
+        <ChampionBox>
+          <ChampionBoxContent></ChampionBoxContent>
+        </ChampionBox>
+      </ContentSide>
+    </Container>
+  );
 }
 
 export default DetailsContentRune;

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/DetailsContentRune.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/DetailsContentRune.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Container, ContentSide, ContentMain, ChampionBox, ChampionBoxContent } from './styles';
 import { keystones, keystonesType } from '@/components/ChampionDetails/championDetailsInfo';
+import RuneTable from './RuneTable';
 
 function DetailsContentRune() {
   const [activeState, setActiveState] = useState(1);
@@ -45,7 +46,9 @@ function DetailsContentRune() {
       </ContentMain>
       <ContentSide>
         <ChampionBox>
-          <ChampionBoxContent></ChampionBoxContent>
+          <ChampionBoxContent>
+            <RuneTable activeState={activeState} />
+          </ChampionBoxContent>
         </ChampionBox>
       </ContentSide>
     </Container>

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/RuneTable/RuneTable.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/RuneTable/RuneTable.tsx
@@ -1,0 +1,384 @@
+import { ChampionRuneTable } from './styles';
+import { runes1, runes2 } from '@/components/ChampionDetails/championDetailsInfo';
+
+interface PropsType {
+  activeState: number;
+}
+
+function RuneTable({ activeState }: PropsType) {
+  return (
+    <ChampionRuneTable>
+      <thead>
+        <tr>
+          <th className="title">룬</th>
+          <th className="sort">픽률</th>
+          <th className="sort">승률</th>
+        </tr>
+      </thead>
+      <tbody className="rune-tbody">
+        {runes1.map((runeRow, i) => (
+          <tr key={'RunePage' + i} className={activeState !== 1 ? 'hide' : ''}>
+            <td className="cell-data">
+              <div className="summary-rune">
+                <div className="rune-box-wrap">
+                  <div className="rune-page">
+                    <div className="rune-page-row">
+                      <div className="rune-item">
+                        <img
+                          src={runeRow.mainRune}
+                          className="rune-image selected"
+                          style={{ backgroundColor: '#ededed' }}
+                        />
+                      </div>
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.keystones.map((keystone, i) => (
+                        <div key={'keystone' + i} className="rune-item">
+                          <img
+                            src={keystone}
+                            alt="키스톤"
+                            className={
+                              keystone.includes('image=c_scale')
+                                ? 'rune-image'
+                                : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.mainFirstLine.map((item, i) => (
+                        <div key={'firstLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="첫번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.mainSecondLine.map((item, i) => (
+                        <div key={'secondLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="두번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.mainThirdLine.map((item, i) => (
+                        <div key={'thirdLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="첫번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="page-divider"></div>
+                  <div className="rune-page">
+                    <div className="rune-page-row">
+                      <div className="rune-item">
+                        <img
+                          src={runeRow.subRune}
+                          className="rune-image selected"
+                          style={{ backgroundColor: '#ededed' }}
+                        />
+                      </div>
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.subFirstLine.map((item, i) => (
+                        <div key={'subFirstLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="첫번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.subSecondLine.map((item, i) => (
+                        <div key={'subSecondLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="두번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.subThirdLine.map((item, i) => (
+                        <div key={'subThirdLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="첫번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="page-divider"></div>
+                  <div className="fragment-page">
+                    <div className="fragment-detail">
+                      <div className="fragment-row">
+                        {runeRow.fragmentFirstLine.map((item, i) => (
+                          <div key={'fragFirstLine' + i} className="fragment">
+                            <img
+                              src={item}
+                              className={
+                                item.includes('image=c_scale')
+                                  ? 'fragment-image opacity'
+                                  : 'fragment-image'
+                              }
+                              alt="스탯"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                      <div className="fragment-row">
+                        {runeRow.fragmentSecondLine.map((item, i) => (
+                          <div key={'fragFirstLine' + i} className="fragment">
+                            <img
+                              src={item}
+                              className={
+                                item.includes('image=c_scale')
+                                  ? 'fragment-image opacity'
+                                  : 'fragment-image'
+                              }
+                              alt="스탯"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                      <div className="fragment-row">
+                        {runeRow.fragmentThirdLine.map((item, i) => (
+                          <div key={'fragFirstLine' + i} className="fragment">
+                            <img
+                              src={item}
+                              className={
+                                item.includes('image=c_scale')
+                                  ? 'fragment-image opacity'
+                                  : 'fragment-image'
+                              }
+                              alt="스탯"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td className="pick-rate item-value">
+              {runeRow.pickRate}%<em>{runeRow.pickCount}</em>
+            </td>
+            <td className="win-rate item-value">{runeRow.winRate}%</td>
+          </tr>
+        ))}
+        {runes2.map((runeRow, i) => (
+          <tr key={'RunePage' + i} className={activeState !== 2 ? 'hide' : ''}>
+            <td className="cell-data">
+              <div className="summary-rune">
+                <div className="rune-box-wrap">
+                  <div className="rune-page">
+                    <div className="rune-page-row">
+                      <div className="rune-item">
+                        <img
+                          src={runeRow.mainRune}
+                          className="rune-image selected"
+                          style={{ backgroundColor: '#ededed' }}
+                        />
+                      </div>
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.keystones.map((keystone, i) => (
+                        <div key={'keystone' + i} className="rune-item">
+                          <img
+                            src={keystone}
+                            alt="키스톤"
+                            className={
+                              keystone.includes('image=c_scale')
+                                ? 'rune-image'
+                                : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.mainFirstLine.map((item, i) => (
+                        <div key={'firstLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="첫번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.mainSecondLine.map((item, i) => (
+                        <div key={'secondLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="두번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.mainThirdLine.map((item, i) => (
+                        <div key={'thirdLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="첫번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="page-divider"></div>
+                  <div className="rune-page">
+                    <div className="rune-page-row">
+                      <div className="rune-item">
+                        <img
+                          src={runeRow.subRune}
+                          className="rune-image selected"
+                          style={{ backgroundColor: '#ededed' }}
+                        />
+                      </div>
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.subFirstLine.map((item, i) => (
+                        <div key={'subFirstLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="첫번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.subSecondLine.map((item, i) => (
+                        <div key={'subSecondLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="두번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="rune-page-row">
+                      {runeRow.subThirdLine.map((item, i) => (
+                        <div key={'subThirdLine' + i} className="rune-item">
+                          <img
+                            src={item}
+                            alt="첫번째줄"
+                            className={
+                              item.includes('image=c_scale') ? 'rune-image' : 'rune-image selected'
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="page-divider"></div>
+                  <div className="fragment-page">
+                    <div className="fragment-detail">
+                      <div className="fragment-row">
+                        {runeRow.fragmentFirstLine.map((item, i) => (
+                          <div key={'fragFirstLine' + i} className="fragment">
+                            <img
+                              src={item}
+                              className={
+                                item.includes('image=c_scale')
+                                  ? 'fragment-image opacity'
+                                  : 'fragment-image'
+                              }
+                              alt="스탯"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                      <div className="fragment-row">
+                        {runeRow.fragmentSecondLine.map((item, i) => (
+                          <div key={'fragFirstLine' + i} className="fragment">
+                            <img
+                              src={item}
+                              className={
+                                item.includes('image=c_scale')
+                                  ? 'fragment-image opacity'
+                                  : 'fragment-image'
+                              }
+                              alt="스탯"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                      <div className="fragment-row">
+                        {runeRow.fragmentThirdLine.map((item, i) => (
+                          <div key={'fragFirstLine' + i} className="fragment">
+                            <img
+                              src={item}
+                              className={
+                                item.includes('image=c_scale')
+                                  ? 'fragment-image opacity'
+                                  : 'fragment-image'
+                              }
+                              alt="스탯"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td className="pick-rate item-value">
+              {runeRow.pickRate}%<em>{runeRow.pickCount}</em>
+            </td>
+            <td className="win-rate item-value">{runeRow.winRate}%</td>
+          </tr>
+        ))}
+      </tbody>
+    </ChampionRuneTable>
+  );
+}
+
+export default RuneTable;

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/RuneTable/index.tsx
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/RuneTable/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './RuneTable';

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/RuneTable/styles.ts
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/RuneTable/styles.ts
@@ -1,0 +1,158 @@
+import styled from 'styled-components';
+
+export const ChampionRuneTable = styled.table`
+  table-layout: auto;
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+  thead {
+    tr {
+      th {
+        vertical-align: middle;
+        height: 39px;
+        background: #fff;
+        border-bottom: 1px solid #e9eff4;
+        line-height: 17px;
+        font-size: 14px;
+        color: #b6b6b6;
+        font-weight: normal;
+        text-align: center;
+        width: 95px;
+        background-image: url(../images/site/champion/select-over.png);
+        background-repeat: no-repeat;
+        background-position: right 20px center;
+      }
+      th.title {
+        background-image: none;
+        cursor: default;
+        width: auto;
+        text-align: left;
+        font-weight: bold;
+        color: #222;
+        padding-left: 20px;
+      }
+      th.sort {
+        background-image: url(../images/site/bg-tableSorter.png);
+        background-repeat: no-repeat;
+        background-position: 90% center;
+        cursor: pointer;
+        outline: none;
+      }
+    }
+  }
+  tbody.rune-tbody {
+    tr {
+      td.cell-data {
+        padding-left: 15px;
+        div.summary-rune {
+          border-top: 1px solid #e9eff4;
+          div.rune-box-wrap {
+            margin: 12px 0;
+            text-align: left;
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            padding: 10px;
+            font-size: 0;
+            div.rune-page {
+              display: inline-block;
+              vertical-align: bottom;
+              max-width: 170px;
+              box-sizing: border-box;
+              div.rune-page-row {
+                display: table;
+                width: 100%;
+                table-layout: fixed;
+                div.rune-item {
+                  display: table-cell;
+                  padding: 4px 0;
+                  text-align: center;
+                  img.rune-image {
+                    display: block;
+                    width: 32px;
+                    height: 32px;
+                    border-radius: 50%;
+                    background: #ededed;
+                    margin: 0 auto;
+                    overflow: hidden;
+                    opacity: 0.5;
+                  }
+                  img.selected {
+                    background-color: black;
+                    opacity: 1;
+                  }
+                }
+                div.main-rune {
+                  width: 100%;
+                }
+                div.keystone {
+                }
+              }
+            }
+            div.page-divider {
+              width: 1px;
+              height: 200px;
+              background-color: #ddd;
+              margin: 0 8px;
+            }
+            div.fragment-page {
+              display: flex;
+              align-items: flex-end;
+              margin: 0px 8px 4px 4px;
+              div.fragment-detail {
+                margin-left: 24px;
+                div.fragment-row {
+                  display: flex;
+                  margin-top: 16px;
+                  div.fragment {
+                    margin-right: 12px;
+                    width: 24px;
+                    height: 24px;
+                    border-radius: 24px;
+                    background-color: #e5e5e5;
+                    img.fragment-image {
+                      display: block;
+                      width: 100%;
+                      height: 100%;
+                    }
+                    img.opacity {
+                      opacity: 0.5;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        div.summary-rune:first-child {
+          border-top: none;
+        }
+      }
+      td.item-value {
+        text-align: center;
+        vertical-align: middle;
+        font-size: 13px;
+      }
+      td.pick-rate {
+        font-weight: bold;
+        color: #4a4a4a;
+        em {
+          display: block;
+          font-size: 11px;
+          color: #999;
+          font-style: normal;
+        }
+      }
+      td.win-rate {
+        font-weight: normal;
+        color: #4a4a4a;
+      }
+    }
+    tr.hide {
+      display: none;
+    }
+    tr:nth-child(even) {
+      background: #ebebed;
+    }
+  }
+`;

--- a/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/styles.ts
+++ b/src/components/ChampionDetails/ChampionDetailsMain/DetailsContents/DetailsContentRune/styles.ts
@@ -1,3 +1,96 @@
 import styled from 'styled-components';
 
-export const DetailsContentRune = styled.div``;
+export const Container = styled.div`
+  display: flex;
+  width: 1080px;
+  margin: 10px auto 0;
+`;
+
+export const ContentMain = styled.div`
+  width: 318px;
+`;
+
+export const ContentSide = styled.div`
+  width: 752px;
+  margin-left: 8px;
+`;
+
+export const ChampionBox = styled.div`
+  margin-top: 10px;
+  background-color: #f9f9fa;
+  border: solid 1px #e6e6e6;
+  div.champion-box-header {
+    position: relative;
+    background: #fff;
+    border-bottom: 1px solid #e6e6e6;
+    text-align: left;
+    h4 {
+      padding: 12px 0 11px 20px;
+      line-height: 17px;
+      font-size: 14px;
+      color: #222;
+      letter-spacing: -0.2px;
+      font-weight: bold;
+    }
+  }
+`;
+
+export const ChampionBoxContent = styled.div`
+  background: #fafafa;
+  overflow: hidden;
+  ul.filter {
+    li.filter-item {
+      border-left: 8px solid transparent;
+      padding: 13px 0 13px 22px;
+      background-color: #f9f9fa;
+      border-top: solid 1px #e9eff4;
+      cursor: pointer;
+      img.rune {
+        display: inline-block;
+        border-radius: 50%;
+        vertical-align: bottom;
+      }
+      img.keystone {
+        background: #000;
+        margin-bottom: -1px;
+        margin-left: -9px;
+      }
+      img.sub-rune {
+        margin-left: 13px;
+      }
+      div.item-value {
+        display: table;
+        margin-top: 10px;
+        div.rate {
+          display: table-row;
+          line-height: 15px;
+          span {
+            padding-top: 5px;
+            display: table-cell;
+            font-size: 12px;
+          }
+          b {
+            display: table-cell;
+            padding-top: 4px;
+            padding-left: 10px;
+            font-size: 13px;
+            font-weight: normal;
+            color: #222;
+          }
+        }
+        div.rate:first-child {
+          b {
+            font-weight: 600;
+          }
+        }
+      }
+    }
+    li.filter-item:first-child {
+      border-top: none;
+    }
+    li.filter-item.active {
+      border-left-color: #3c8eec;
+      background: #fff;
+    }
+  }
+`;

--- a/src/components/ChampionDetails/championDetailsInfo.ts
+++ b/src/components/ChampionDetails/championDetailsInfo.ts
@@ -57,6 +57,612 @@ export const keystones = [
   },
 ];
 
+export const runes1 = [
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=q_auto:best&v=1618413338',
+    keystones: [
+      '//opgg-static.akamaized.net/images/lol/perk/8005.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8021.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=q_auto:best&v=1618413338',
+    ],
+    mainFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9101.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9111.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8009.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9104.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/9105.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9103.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8014.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8017.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8299.png?image=q_auto:best&v=1618413338',
+    ],
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8200.png?image=q_auto:best&v=1618413338',
+    subFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8224.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8226.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8275.png?image=q_auto:best&v=1618413338',
+    ],
+    subSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8210.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8234.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8233.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8237.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8232.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8236.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5005.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5007.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5001.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=q_auto:best&v=1618413338',
+    ],
+    pickRate: 27.1,
+    pickCount: 351,
+    winRate: 51.57,
+  },
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=q_auto:best&v=1618413338',
+    keystones: [
+      '//opgg-static.akamaized.net/images/lol/perk/8005.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8021.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=q_auto:best&v=1618413338',
+    ],
+    mainFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9101.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9111.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8009.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9104.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/9105.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9103.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8014.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8017.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8299.png?image=q_auto:best&v=1618413338',
+    ],
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8200.png?image=q_auto:best&v=1618413338',
+    subFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8224.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8226.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8275.png?image=q_auto:best&v=1618413338',
+    ],
+    subSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8210.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8234.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8233.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8237.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8232.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8236.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5005.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5007.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5001.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    pickRate: 10.35,
+    pickCount: 134,
+    winRate: 49.25,
+  },
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=q_auto:best&v=1618413338',
+    keystones: [
+      '//opgg-static.akamaized.net/images/lol/perk/8005.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8021.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=q_auto:best&v=1618413338',
+    ],
+    mainFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9101.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9111.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8009.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9104.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9105.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/9103.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8014.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8017.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8299.png?image=q_auto:best&v=1618413338',
+    ],
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8200.png?image=q_auto:best&v=1618413338',
+    subFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8224.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8226.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8275.png?image=q_auto:best&v=1618413338',
+    ],
+    subSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8210.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8234.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8233.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8237.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8232.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8236.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5005.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5007.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5001.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    pickRate: 8.49,
+    pickCount: 110,
+    winRate: 48.18,
+  },
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=q_auto:best&v=1618413338',
+    keystones: [
+      '//opgg-static.akamaized.net/images/lol/perk/8005.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8021.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=q_auto:best&v=1618413338',
+    ],
+    mainFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9101.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9111.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8009.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9104.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/9105.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9103.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8014.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8017.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8299.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8200.png?image=q_auto:best&v=1618413338',
+    subFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8224.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8226.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8275.png?image=q_auto:best&v=1618413338',
+    ],
+    subSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8210.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8234.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8233.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8237.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8232.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8236.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5005.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5007.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5001.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    pickRate: 3.32,
+    pickCount: 43,
+    winRate: 48.84,
+  },
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=q_auto:best&v=1618413338',
+    keystones: [
+      '//opgg-static.akamaized.net/images/lol/perk/8005.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8021.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=q_auto:best&v=1618413338',
+    ],
+    mainFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9101.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9111.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8009.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9104.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9105.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/9103.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8014.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8017.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8299.png?image=q_auto:best&v=1618413338',
+    ],
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8200.png?image=q_auto:best&v=1618413338',
+    subFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8224.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8226.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8275.png?image=q_auto:best&v=1618413338',
+    ],
+    subSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8210.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8234.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8233.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8237.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8232.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8236.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5005.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5007.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5001.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=q_auto:best&v=1618413338',
+    ],
+    pickRate: 3.17,
+    pickCount: 41,
+    winRate: 56.1,
+  },
+];
+
+export const runes2 = [
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=q_auto:best&v=1618413338',
+    keystones: [
+      '//opgg-static.akamaized.net/images/lol/perk/8005.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8021.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=q_auto:best&v=1618413338',
+    ],
+    mainFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9101.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9111.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8009.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9104.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/9105.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9103.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8014.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8017.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8299.png?image=q_auto:best&v=1618413338',
+    ],
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8400.png?image=q_auto:best&v=1618413338',
+    subFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8446.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8463.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8401.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8429.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8444.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8473.png?image=q_auto:best&v=1618413338',
+    ],
+    subThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8451.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8453.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8242.png?image=q_auto:best&v=1618413338',
+    ],
+    fragmentFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5005.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5007.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5001.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=q_auto:best&v=1618413338',
+    ],
+    pickRate: 6.49,
+    pickCount: 84,
+    winRate: 52.38,
+  },
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=q_auto:best&v=1618413338',
+    keystones: [
+      '//opgg-static.akamaized.net/images/lol/perk/8005.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8021.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=q_auto:best&v=1618413338',
+    ],
+    mainFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9101.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9111.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8009.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9104.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/9105.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9103.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8014.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8017.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8299.png?image=q_auto:best&v=1618413338',
+    ],
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8400.png?image=q_auto:best&v=1618413338',
+    subFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8446.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8463.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8401.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8429.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8444.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8473.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8451.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8453.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8242.png?image=q_auto:best&v=1618413338',
+    ],
+    fragmentFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5005.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5007.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5001.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=q_auto:best&v=1618413338',
+    ],
+    pickRate: 2.55,
+    pickCount: 33,
+    winRate: 60.61,
+  },
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=q_auto:best&v=1618413338',
+    keystones: [
+      '//opgg-static.akamaized.net/images/lol/perk/8005.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8021.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=q_auto:best&v=1618413338',
+    ],
+    mainFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9101.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9111.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8009.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9104.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/9105.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9103.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8014.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8017.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8299.png?image=q_auto:best&v=1618413338',
+    ],
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8400.png?image=q_auto:best&v=1618413338',
+    subFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8446.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8463.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8401.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8429.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8444.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8473.png?image=q_auto:best&v=1618413338',
+    ],
+    subThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8451.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8453.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8242.png?image=q_auto:best&v=1618413338',
+    ],
+    fragmentFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5005.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5007.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5001.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=q_auto:best&v=1618413338',
+    ],
+    pickRate: 2.24,
+    pickCount: 29,
+    winRate: 62.07,
+  },
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=q_auto:best&v=1618413338',
+    keystones: [
+      '//opgg-static.akamaized.net/images/lol/perk/8005.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8021.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=q_auto:best&v=1618413338',
+    ],
+    mainFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9101.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9111.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8009.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9104.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/9105.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9103.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8014.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8017.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8299.png?image=q_auto:best&v=1618413338',
+    ],
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8400.png?image=q_auto:best&v=1618413338',
+    subFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8446.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8463.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8401.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8429.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8444.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8473.png?image=q_auto:best&v=1618413338',
+    ],
+    subThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8451.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8453.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8242.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5005.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5007.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5001.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=q_auto:best&v=1618413338',
+    ],
+    pickRate: 1.78,
+    pickCount: 23,
+    winRate: 52.17,
+  },
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=q_auto:best&v=1618413338',
+    keystones: [
+      '//opgg-static.akamaized.net/images/lol/perk/8005.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8021.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=q_auto:best&v=1618413338',
+    ],
+    mainFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9101.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9111.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8009.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/9104.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/9105.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/9103.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    mainThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8014.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8017.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8299.png?image=q_auto:best&v=1618413338',
+    ],
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8400.png?image=q_auto:best&v=1618413338',
+    subFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8446.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8463.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8401.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8429.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8444.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perk/8473.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    subThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perk/8451.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8453.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perk/8242.png?image=q_auto:best&v=1618413338',
+    ],
+    fragmentFirstLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5005.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5007.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentSecondLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5008.png?image=q_auto:best&v=1618413338',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=c_scale,q_auto,e_grayscale&v=1',
+    ],
+    fragmentThirdLine: [
+      '//opgg-static.akamaized.net/images/lol/perkShard/5001.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5002.png?image=c_scale,q_auto,e_grayscale&v=1',
+      '//opgg-static.akamaized.net/images/lol/perkShard/5003.png?image=q_auto:best&v=1618413338',
+    ],
+    pickRate: 1.78,
+    pickCount: 23,
+    winRate: 60.87,
+  },
+];
+
 export const firstSkillOrder = [
   {
     skills: ['Q', 'W', 'E', 'Q', 'Q', 'R', 'Q', 'E', 'Q', 'E', 'R', 'E', 'E', 'W', 'W'],

--- a/src/components/ChampionDetails/championDetailsInfo.ts
+++ b/src/components/ChampionDetails/championDetailsInfo.ts
@@ -1,5 +1,13 @@
 import { IChampion } from '@/types/champion';
 
+export interface keystonesType {
+  mainRune: string;
+  keystone: string;
+  subRune: string;
+  pickRate: number;
+  winRate: number;
+}
+
 export const getSkillsInfo = (champion: IChampion) => {
   const championPassiveSkill = `http://ddragon.leagueoflegends.com/cdn/11.7.1/img/passive/${champion.passive.image.full}`;
   const championSkillUrl: string[] = [];
@@ -24,6 +32,29 @@ export const precisionRune = [
   ['9101', '9111', '8009'],
   ['9104', '9105', '9103'],
   ['8014', '8017', '8299'],
+];
+
+export const keystones = [
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=c_scale,q_auto,w_26&v=1618413338',
+    keystone:
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=c_scale,q_auto,w_42&v=1618413338',
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8200.png?image=c_scale,q_auto,w_32&v=1618413338',
+    pickRate: 63.17,
+    winRate: 51.83,
+  },
+  {
+    mainRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8000.png?image=c_scale,q_auto,w_26&v=1618413338',
+    keystone:
+      '//opgg-static.akamaized.net/images/lol/perk/8010.png?image=c_scale,q_auto,w_42&v=1618413338',
+    subRune:
+      '//opgg-static.akamaized.net/images/lol/perkStyle/8400.png?image=c_scale,q_auto,w_32&v=1618413338',
+    pickRate: 32.74,
+    winRate: 54.72,
+  },
 ];
 
 export const firstSkillOrder = [


### PR DESCRIPTION
## 개요 🪧

- 룬 탭 구현
 
## 작업 내용 📄

- championDetailsInfo.ts 파일에 룬 테이블 관련 목업 데이터 추가
- 탭 메뉴 구현

## 변경 로직 ⚙️

- X

## 스크린샷 📸
![image](https://user-images.githubusercontent.com/73068489/115021888-8b882c00-9ef7-11eb-9564-b6399c894816.png)
![image](https://user-images.githubusercontent.com/73068489/115021914-95119400-9ef7-11eb-8485-fe0f22a07813.png)
