### PR TITLE
[FIX] Mixed Content 에러 해결

### DIFF
--- a/src/components/ChampionDetails/championDetailsInfo.ts
+++ b/src/components/ChampionDetails/championDetailsInfo.ts
@@ -9,12 +9,12 @@ export interface keystonesType {
 }
 
 export const getSkillsInfo = (champion: IChampion) => {
-  const championPassiveSkill = `http://ddragon.leagueoflegends.com/cdn/11.7.1/img/passive/${champion.passive.image.full}`;
+  const championPassiveSkill = `https://ddragon.leagueoflegends.com/cdn/11.7.1/img/passive/${champion.passive.image.full}`;
   const championSkillUrl: string[] = [];
   championSkillUrl.push(championPassiveSkill);
   champion.spells.map((spell) =>
     championSkillUrl.push(
-      `http://ddragon.leagueoflegends.com/cdn/11.7.1/img/spell/${spell.image.full}`,
+      `https://ddragon.leagueoflegends.com/cdn/11.7.1/img/spell/${spell.image.full}`,
     ),
   );
 

--- a/src/components/SearchExtra/SearchAutoComplete/SearchAutoCompleteItem.tsx
+++ b/src/components/SearchExtra/SearchAutoComplete/SearchAutoCompleteItem.tsx
@@ -48,7 +48,7 @@ function SearchAutoCompleteItem({ item, refFn, isFocused }: SearchAutoCompleteIt
 }
 
 function imageLoader({ src }: { src: string }) {
-  return `http://ddragon.leagueoflegends.com/cdn/11.8.1/img${src}`;
+  return `https://ddragon.leagueoflegends.com/cdn/11.8.1/img${src}`;
 }
 function refineItem(item: SummonerRank | SearchChampionMeta) {
   return {

--- a/src/lib/api/championInfo.ts
+++ b/src/lib/api/championInfo.ts
@@ -3,7 +3,7 @@ import client from './client';
 
 export default async function getChampion(championName = '') {
   const championUrl = championName.replace(/(^|\s)\S/g, (char: string) => char.toUpperCase());
-  const apiUrl = `http://ddragon.leagueoflegends.com/cdn/11.7.1/data/ko_KR/champion/${championUrl}.json`;
+  const apiUrl = `https://ddragon.leagueoflegends.com/cdn/11.7.1/data/ko_KR/champion/${championUrl}.json`;
 
   const response = await client.get<ChampionInfo>(apiUrl);
   const { data } = response.data;


### PR DESCRIPTION


## 개요 🪧
 검색 자동완성에서 챔피언, 소환사 썸네일 이미지가 깨지고 Mixed Content 에러 발생하는 이슈 해결
- https에서 http로 api 호출 할 경우 발생하는 에러

## 작업 내용 📄

- 이미지 url 프로토콜 https로 변경

## 변경 로직 ⚙️

## 스크린샷 📸
